### PR TITLE
Allow FAB Speed Dial to work for both touch and mouse devices

### DIFF
--- a/src/components/fabSpeedDial/fabController.js
+++ b/src/components/fabSpeedDial/fabController.js
@@ -115,20 +115,27 @@
       events.push(latestEvent.type);
 
       // Handle desktop click
-      if (equalsEvents(['mousedown', 'focusout?', 'focusin?', 'mouseup', 'click'])) {
+      if (equalsEvents(['mousedown', 'mouseup'])) {
         handleItemClick(latestEvent);
         resetEvents();
         return;
       }
 
       // Handle mobile click/tap (and keyboard enter)
-      if (equalsEvents(['touchstart?', 'touchend?', 'click'])) {
+      if (equalsEvents(['touchstart', 'touchend'])) {
         handleItemClick(latestEvent);
         resetEvents();
         return;
       }
 
-      // Handle tab keys (focusin)
+        // Handle mobile click/tap (and keyboard enter)
+      if (equalsEvents(['click'])) {
+          handleItemClick(latestEvent);
+          resetEvents();
+          return;
+      }
+
+        // Handle tab keys (focusin)
       if (equalsEvents(['focusin'])) {
         vm.open();
         resetEvents();


### PR DESCRIPTION
FAB Speed Dial should work on touch devices (e.g. - iPad, Android), mouse, and devices that support both (e.g. - Windows 10 on Surface Pro).
